### PR TITLE
Replace Lucida Grande to system font(s)

### DIFF
--- a/css/src/components/tabs.css
+++ b/css/src/components/tabs.css
@@ -136,7 +136,6 @@ li.tabs__tab a {
   padding-left: 4px;
   border-left: 0; /* LTR */
   border-radius: 0 4px 0 0; /* LTR */
-  font-family: Arial, sans-serif;
   font-size: 1.25em;
   letter-spacing: 0.1em;
   text-align: center;

--- a/css/src/theme/ckeditor-dialog.css
+++ b/css/src/theme/ckeditor-dialog.css
@@ -27,7 +27,7 @@
   background: none;
 }
 .cke_reset_all .cke_dialog_body * {
-  font: 13px/1.538em "Lucida Grande", "Lucida Sans Unicode", "DejaVu Sans", "Lucida Sans", sans-serif;
+  font: 13px/1.538em var(--font-family);
 }
 
 /* Dialog's header. */

--- a/variables.js
+++ b/variables.js
@@ -6,6 +6,6 @@ module.exports = {
     '--color-link': '#0074bd',
     '--color-divider': 'rgba(142, 146, 156, 0.4)',
     // Typography.
-    '--font-family': 'BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;'
+    '--font-family': 'BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif'
   }
 }

--- a/variables.js
+++ b/variables.js
@@ -6,6 +6,6 @@ module.exports = {
     '--color-link': '#0074bd',
     '--color-divider': 'rgba(142, 146, 156, 0.4)',
     // Typography.
-    '--font-family': '\"Lucida Grande\", \"Lucida Sans Unicode\", \"DejaVu Sans\", \"Lucida Sans\", sans-serif'
+    '--font-family': 'BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;'
   }
 }


### PR DESCRIPTION
## Issue

This PR fix #33 by replacing fonts used in the theme by _WordPress font stack_  (This is the one which looks _”more native”_ in Ubuntu).

## Screenshot / UI changes

https://github.com/drupalux/seven/pull/54#issuecomment-436985002
https://github.com/drupalux/seven/issues/33#issuecomment-437303889

## Testing instructions

Follow project readme.
* `yarn install`
*  `rm -rf css/dist`
* `yarn build:css`
* `drush si`
