### PR TITLE
Fix status report icons

### DIFF
--- a/css/src/components/system-status-counter.css
+++ b/css/src/components/system-status-counter.css
@@ -39,13 +39,13 @@
 }
 
 .system-status-counter__status-icon--error:before {
-  background-image: url(../../../stable/images/core/icons/e32700/error.svg);
+  background-image: url(../../../../../../core/themes/stable/images/core/icons/e32700/error.svg);
 }
 .system-status-counter__status-icon--warning:before {
-  background-image: url(../../../stable/images/core/icons/e29700/warning.svg);
+  background-image: url(../../../../../../core/themes/stable/images/core/icons/e29700/warning.svg);
 }
 .system-status-counter__status-icon--checked:before {
-  background-image: url(../../../stable/images/core/icons/73b355/check.svg);
+  background-image: url(../../../../../../core/themes/stable/images/core/icons/73b355/check.svg);
 }
 
 .system-status-counter__status-title {

--- a/css/src/components/system-status-report.css
+++ b/css/src/components/system-status-report.css
@@ -88,11 +88,11 @@
 }
 .system-status-report__status-icon--error .details-title:before,
 .details .system-status-report__status-icon--error:before {
-  background-image: url(../../../stable/images/core/icons/e32700/error.svg);
+  background-image: url(../../../../../../core/themes/stable/images/core/icons/e32700/error.svg);
 }
 .system-status-report__status-icon--warning .details-title:before,
 .details .system-status-report__status-icon--warning:before {
-  background-image: url(../../../stable/images/core/icons/e29700/warning.svg);
+  background-image: url(../../../../../../core/themes/stable/images/core/icons/e29700/warning.svg);
 }
 
 .system-status-report__entry__value {


### PR DESCRIPTION
## Issue

This PR fix #65.

## Screenshot / UI changes

Fixed icons on status reports page.

[Status-report.zip](https://github.com/drupalux/seven/files/2608894/Status-report.zip)

## Testing instructions

* Add `https://github.com/zolhorvath/seven-refresh/` as `drupal-profile` (`sevenrefresh`)
* Remove `core/themes/seven`
* Make sure that this theme is installed to `themes/custom/seven`
* Symlink `core/misc` to `themes/custom/misc`
* Run `yarn && yarn build:css` in the theme's root
* Install a Drupal with profile `sevenrefresh`. 
* Visit the status report page at `/admin/reports/status`.




