### PR TITLE
Apply Text area (mainly WYSIWYG editor) style updates

### DIFF
--- a/claro.info.yml
+++ b/claro.info.yml
@@ -47,6 +47,15 @@ libraries-override:
       component:
         css/components/details.css: false
         css/components/form.css: false
+  # @todo Refactor when https://www.drupal.org/node/2642122 is fixed.
+  filter/drupal.filter.admin:
+    css:
+      theme:
+        /core/themes/stable/css/filter/filter.admin.css: css/dist/theme/filter.theme.css
+  filter/drupal.filter:
+    css:
+      theme:
+        /core/themes/stable/css/filter/filter.admin.css: css/dist/theme/filter.theme.css
 
 libraries-extend:
   core/ckeditor:

--- a/claro.info.yml
+++ b/claro.info.yml
@@ -68,6 +68,8 @@ libraries-extend:
     - claro/tour-styling
   classy/image-widget:
     - claro/image-widget
+  ckeditor/drupal.ckeditor:
+    - claro/ckeditor-editor
 
 quickedit_stylesheets:
   - css/dist/components/quickedit.css

--- a/claro.info.yml
+++ b/claro.info.yml
@@ -73,6 +73,10 @@ libraries-extend:
 
 quickedit_stylesheets:
   - css/dist/components/quickedit.css
+ckeditor_stylesheets:
+  - css/dist/base/elements.css
+  - css/dist/base/typography.css
+
 regions:
   header: 'Header'
   pre_content: 'Pre-content'

--- a/claro.libraries.yml
+++ b/claro.libraries.yml
@@ -122,6 +122,12 @@ ckeditor-dialog:
     theme:
       css/dist/theme/ckeditor-dialog.css: {}
 
+ckeditor-editor:
+  version: VERSION
+  css:
+    theme:
+      css/dist/theme/ckeditor-editor.css: {}
+
 tour-styling:
   version: VERSION
   css:

--- a/claro.theme
+++ b/claro.theme
@@ -8,6 +8,7 @@
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\media\MediaForm;
+use Drupal\Core\Template\Attribute;
 
 /**
  * Implements hook_preprocess_HOOK() for HTML document templates.
@@ -118,7 +119,6 @@ function claro_preprocess_menu_local_action(array &$variables) {
 
   // We require Modernizr's touch test for button styling.
   $variables['#attached']['library'][] = 'core/modernizr';
-  $variables['#attached']['library'][] = 'core/modernizr';
 }
 
 /**
@@ -128,6 +128,53 @@ function claro_element_info_alter(&$type) {
   // We require Modernizr for button styling.
   if (isset($type['button'])) {
     $type['button']['#attached']['library'][] = 'core/modernizr';
+  }
+
+  // @todo Remove when https://www.drupal.org/node/3016343 is fixed.
+  if (isset($types['text_format'])) {
+    $types['text_format']['#pre_render'][] = '_claro_text_format_prerender';
+  }
+}
+
+/**
+ * Prerender callback for text_format elements.
+ *
+ * Fixes JS inconsistencies of the 'text_textarea_with_summary' widgets.
+ *
+ * @todo Remove when https://www.drupal.org/node/3016343 is fixed.
+ */
+function _claro_text_format_prerender($element) {
+  if (
+    !empty($element['summary']) &&
+    $element['summary']['#type'] === 'textarea'
+  ) {
+    $element['#attributes']['class'][] = 'js-text-format-wrapper';
+    $element['value']['#wrapper_attributes']['class'][] = 'js-form-type-textarea';
+  }
+  return $element;
+}
+
+/**
+ * Implements template_preprocess_text_format_wrapper().
+ *
+ * @todo Remove when https://www.drupal.org/node/3016343 is fixed.
+ */
+function claro_preprocess_text_format_wrapper(&$variables) {
+  $description_attributes = [];
+  if (!empty($variables['attributes']['id'])) {
+    $description_attributes['id'] = $variables['attributes']['aria-describedby'] = $variables['attributes']['id'];
+    unset($variables['attributes']['id']);
+  }
+  $variables['description_attributes'] = new Attribute($description_attributes);
+}
+
+/**
+ * Implements hook_theme_registry_alter().
+ */
+function claro_theme_registry_alter(&$theme_registry) {
+  // @todo Remove when https://www.drupal.org/node/3016346 is fixed.
+  if (!empty($theme_registry['text_format_wrapper'])) {
+    $theme_registry['text_format_wrapper']['variables']['disabled'] = FALSE;
   }
 }
 

--- a/claro.theme
+++ b/claro.theme
@@ -162,6 +162,7 @@ function _claro_text_format_prerender($element) {
  */
 function claro_preprocess_filter_guidelines(&$variables) {
   // Fix filter guidelines selector issue of 'filter/drupal.filter'.
+  // @todo Remove when https://www.drupal.org/node/2881212 is fixed.
   $variables['attributes']['class'][] = 'filter-guidelines-item';
   $variables['attributes']['class'][] = 'filter-guidelines-' . $variables['format']->id();
 }

--- a/claro.theme
+++ b/claro.theme
@@ -124,13 +124,13 @@ function claro_preprocess_menu_local_action(array &$variables) {
 /**
  * Implements hook_element_info_alter().
  */
-function claro_element_info_alter(&$type) {
+function claro_element_info_alter(&$types) {
   // We require Modernizr for button styling.
-  if (isset($type['button'])) {
-    $type['button']['#attached']['library'][] = 'core/modernizr';
+  if (isset($types['button'])) {
+    $types['button']['#attached']['library'][] = 'core/modernizr';
   }
 
-  // @todo Remove when https://www.drupal.org/node/3016343 is fixed.
+  // @todo Refactor when https://www.drupal.org/node/3016343 is fixed.
   if (isset($types['text_format'])) {
     $types['text_format']['#pre_render'][] = '_claro_text_format_prerender';
   }
@@ -138,12 +138,15 @@ function claro_element_info_alter(&$type) {
 
 /**
  * Prerender callback for text_format elements.
- *
- * Fixes JS inconsistencies of the 'text_textarea_with_summary' widgets.
- *
- * @todo Remove when https://www.drupal.org/node/3016343 is fixed.
  */
 function _claro_text_format_prerender($element) {
+  // Add clearfix for filter wrapper.
+  $element['format']['#attributes']['class'][] = 'clearfix';
+  // Hide format select label visually.
+  $element['format']['format']['#title_display'] = 'invisible';
+
+  // Fix JS inconsistencies of the 'text_textarea_with_summary' widgets.
+  // @todo Remove when https://www.drupal.org/node/3016343 is fixed.
   if (
     !empty($element['summary']) &&
     $element['summary']['#type'] === 'textarea'
@@ -152,6 +155,15 @@ function _claro_text_format_prerender($element) {
     $element['value']['#wrapper_attributes']['class'][] = 'js-form-type-textarea';
   }
   return $element;
+}
+
+/**
+ * Implements template_preprocess_filter_guidelines().
+ */
+function claro_preprocess_filter_guidelines(&$variables) {
+  // Fix filter guidelines selector issue of 'filter/drupal.filter'.
+  $variables['attributes']['class'][] = 'filter-guidelines-item';
+  $variables['attributes']['class'][] = 'filter-guidelines-' . $variables['format']->id();
 }
 
 /**

--- a/css/src/base/elements.css
+++ b/css/src/base/elements.css
@@ -8,6 +8,10 @@ body {
   font: normal 16px/1.5 var(--font-family);
 }
 
+body.cke_editable {
+  margin: 1em calc(1em - var(--size-input-border) - var(--size-input-border));
+}
+
 a,
 .link {
   color: var(--color-link);

--- a/css/src/base/elements.css
+++ b/css/src/base/elements.css
@@ -131,10 +131,12 @@ ul {
   list-style-type: disc;
   list-style-image: none;
   margin: 0.25em 0 0.25em 1.5em; /* LTR */
+  padding-left: 0;
 }
 [dir="rtl"] ul {
   margin-left: 0;
   margin-right: 1.5em;
+  padding-right: 0;
 }
 /* This is required to win over specificity of [dir="rtl"] ul */
 [dir="rtl"] .messages__list {

--- a/css/src/components/buttons.css
+++ b/css/src/components/buttons.css
@@ -160,13 +160,7 @@
   background: none;
   -webkit-appearance: none;
   -moz-appearance: none;
-  color: #0074bd;
   text-decoration: none;
-}
-.link:hover,
-.link:focus {
-  color: #008ee6;
-  text-decoration: underline;
 }
 
 /**

--- a/css/src/components/form--text.css
+++ b/css/src/components/form--text.css
@@ -74,6 +74,9 @@
 
 .form-element[disabled] {
   color: var(--color-input-fg-disabled);
+  /* https://stackoverflow.com/q/262158#answer-23511280 */
+  -webkit-text-fill-color: var(--color-input-fg-disabled);
+  -webkit-opacity: 1;
   background-color: var(--color-input-bg-disabled);
   border-color: var(--color-input-border-disabled);
   box-shadow: none;

--- a/css/src/components/form.css
+++ b/css/src/components/form.css
@@ -184,16 +184,15 @@ td > .form-item:only-child {
  * @legacy
  * @todo Not sure that this is the right component for this.
  */
-ul.tips {
-  margin: 0.2em 0 0 0;
-  color: #595959;
-  /* font-size: 0.95em; */
+.tips {
+  padding-left: 0;
 }
-ul.tips li {
-  margin: 0.25em 0 0.25em 1.5em; /* LTR */
+[dir="rtl"] .tips {
+  padding-right: 0;
 }
-[dir="rtl"] ul.tips li {
-  margin: 0.25em 1.5em 0.25em 0;
+.tips li {
+  margin-top: 1em;
+  margin-bottom: 1em;
 }
 
 /**

--- a/css/src/theme/ckeditor-editor.css
+++ b/css/src/theme/ckeditor-editor.css
@@ -98,7 +98,7 @@
 }
 [disabled] + .cke iframe,
 [disabled] + .cke .cke_source {
-  opacity: 0.5;
+  opacity: 0.505;
 }
 [disabled] + .cke .cke_bottom {
   background: var(--color-input-bg-disabled);

--- a/css/src/theme/ckeditor-editor.css
+++ b/css/src/theme/ckeditor-editor.css
@@ -1,0 +1,109 @@
+/**
+ * @file
+ * CKEditor appearance overrides.
+ */
+
+.cke .cke_top,
+.cke .cke_bottom,
+.cke .cke_contents,
+.cke.cke_chrome {
+  transition: border-color var(--speed-transition) ease-in-out 0s;
+}
+
+.cke.cke_chrome {
+  border-radius: 0.125em; /* (2 / 16) */
+}
+
+.cke .cke_inner {
+  border-radius: 0.0625em; /* (1 / 16) */
+}
+
+.cke_path_empty:only-child::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: var(--color-input-bg);
+  content: "";
+}
+
+.cke .cke_top {
+  border: 0.0625em solid transparent;
+  border-bottom: 0;
+  border-radius: 0.0625em 0.0625em 0 0;
+}
+
+.cke .cke_contents {
+  border: 0.0625em solid transparent;
+  border-top: 0;
+  border-bottom: 0;
+}
+
+.cke .cke_bottom {
+  border: 0.0625em solid transparent;
+  border-top: 0;
+  border-radius: 0 0 0.0625em 0.0625em;
+}
+
+/* Default */
+.cke.cke_chrome {
+  border-color: var(--color-input-border);
+}
+
+/* Error. */
+.error + .cke.cke_chrome,
+.error + .cke .cke_contents,
+.error + .cke .cke_top,
+.error + .cke .cke_bottom {
+  border-color: var(--color-input-border-error);
+}
+
+/* Hover. */
+.cke.cke_chrome:hover,
+.cke:hover .cke_contents,
+.cke:hover .cke_top,
+.cke:hover .cke_bottom,
+.error + .cke.cke_chrome:hover,
+.error + .cke:hover .cke_contents,
+.error + .cke:hover .cke_top,
+.error + .cke:hover .cke_bottom {
+  border-color: var(--color-input-border-hover);
+}
+
+/* Focus. */
+.cke.cke_chrome.cke_focus,
+.cke.cke_focus .cke_contents,
+.cke.cke_focus .cke_top,
+.cke.cke_focus .cke_bottom,
+.error + .cke.cke_chrome.cke_focus,
+.error + .cke.cke_focus .cke_contents,
+.error + .cke.cke_focus .cke_top,
+.error + .cke.cke_focus .cke_bottom {
+  border-color: var(--color-input-border-focus);
+}
+
+/* Disabled. */
+[disabled] + .cke.cke_chrome {
+  border-color: var(--color-input-border-disabled);
+}
+[disabled] + .cke .cke_contents,
+[disabled] + .cke .cke_top,
+[disabled] + .cke .cke_bottom {
+  border-color: transparent;
+}
+[disabled] + .cke .cke_contents {
+  background: hsl(240, 4%, 90%); /* Calculated from disabled input bg and iframe opacity. */
+  border-color: var(--color-input-bg-disabled);
+}
+[disabled] + .cke iframe,
+[disabled] + .cke .cke_source {
+  opacity: 0.5;
+}
+[disabled] + .cke .cke_bottom {
+  background: var(--color-input-bg-disabled);
+}
+[disabled] + .cke .cke_bottom > * {
+  /* Don't show element path dor disabled editor. */
+  opacity: 0;
+}

--- a/css/src/theme/ckeditor-editor.css
+++ b/css/src/theme/ckeditor-editor.css
@@ -29,9 +29,9 @@
 }
 
 .cke .cke_top {
-  border: 0.0625em solid transparent;
+  border: 0.0833em solid transparent; /* Moono lisa skin uses font-size 12px */
   border-bottom: 0;
-  border-radius: 0.0625em 0.0625em 0 0;
+  border-radius: 0.0833em 0.0833em 0 0;
 }
 
 .cke .cke_contents {
@@ -41,9 +41,9 @@
 }
 
 .cke .cke_bottom {
-  border: 0.0625em solid transparent;
+  border: 0.0833em solid transparent; /* Moono lisa skin uses font-size 12px */
   border-top: 0;
-  border-radius: 0 0 0.0625em 0.0625em;
+  border-radius: 0 0 0.0833em 0.0833em;
 }
 
 /* Default */
@@ -106,4 +106,7 @@
 [disabled] + .cke .cke_bottom > * {
   /* Don't show element path dor disabled editor. */
   opacity: 0;
+}
+[disabled] + .cke .cke_path_empty::after {
+  content: none;
 }

--- a/css/src/theme/filter.theme.css
+++ b/css/src/theme/filter.theme.css
@@ -12,10 +12,9 @@
 
 .filter-wrapper {
   border: 0;
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+  margin-top: 0.5em; /* (8 / 16) */
+  margin-bottom: 0.5em; /* (8 / 16) */
   padding: 0;
-  overflow: hidden;
 }
 .filter-wrapper .form-item {
   margin: 0;
@@ -25,56 +24,29 @@
 }
 
 .filter-help {
+  padding-top: 0.25em; /* (3 / 12), because font size is 12px */
+  padding-bottom: 0.25em; /* (3 / 12) */
+  font-size: 0.75em; /* (12 / 16), inherited font size is 16px */
   float: right; /* LTR */
 }
 [dir="rtl"] .filter-help {
   float: left;
 }
-.filter-guidelines .filter-guidelines-item {
-  margin-top: 1em;
-}
-.filter-help p {
-  margin: 0;
-}
-.filter-help a {
-  position: relative;
-  margin: 0 20px 0 0; /* LTR */
-}
-[dir="rtl"] .filter-help a {
-  margin: 0 0 0 20px;
-}
-.filter-help a:after {
-  position: absolute;
-  top: 0;
-  right: -20px; /* LTR */
-  content: '';
-  display: block;
-  width: 16px;
-  height: 16px;
-  background: transparent url("../../../../../../core/themes/stable/images/core/help.png");
-}
-[dir="rtl"] .filter-help a:after {
-  right: auto;
-  left: -20px;
-}
-
-.text-format-wrapper .description {
-  margin-top: 0.5em;
-}
-.tips {
-  font-size: 0.9em;
-  margin-bottom: 0;
-  margin-top: 0;
-  padding-bottom: 0;
-  padding-top: 0;
-}
 
 /**
- * Improve filter tips position.
+ * Filter guidelines.
  */
-.tips {
-  padding-left: 0; /* LTR */
+.filter-guidelines__item {
+  margin-top: 0.5em; /* (6 / 12) */
+  font-size: 0.75em; /* (12 / 16) */
+  color: var(--color-description-fg);
 }
-[dir="rtl"] .tips {
-  padding-right: 0;
+/* Filter tips. */
+.filter-guidelines__item .tips li {
+  margin-top: 0.3333em; /* (4 / 12) */
+  margin-bottom: 0;
+}
+.filter-guidelines__item p {
+  margin-top: 0.3333em; /* (4 / 12) */
+  margin-bottom: 0;
 }

--- a/css/src/theme/filter.theme.css
+++ b/css/src/theme/filter.theme.css
@@ -1,0 +1,80 @@
+/**
+ * @file
+ * Styling for the Filter module.
+ */
+
+/**
+ * Filter information under field.
+ */
+.text-full > .form-item {
+  margin-bottom: 0;
+}
+
+.filter-wrapper {
+  border: 0;
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+  padding: 0;
+  overflow: hidden;
+}
+.filter-wrapper .form-item {
+  margin: 0;
+}
+.filter-wrapper .form-item label {
+  display: inline;
+}
+
+.filter-help {
+  float: right; /* LTR */
+}
+[dir="rtl"] .filter-help {
+  float: left;
+}
+.filter-guidelines .filter-guidelines-item {
+  margin-top: 1em;
+}
+.filter-help p {
+  margin: 0;
+}
+.filter-help a {
+  position: relative;
+  margin: 0 20px 0 0; /* LTR */
+}
+[dir="rtl"] .filter-help a {
+  margin: 0 0 0 20px;
+}
+.filter-help a:after {
+  position: absolute;
+  top: 0;
+  right: -20px; /* LTR */
+  content: '';
+  display: block;
+  width: 16px;
+  height: 16px;
+  background: transparent url("../../../../../../core/themes/stable/images/core/help.png");
+}
+[dir="rtl"] .filter-help a:after {
+  right: auto;
+  left: -20px;
+}
+
+.text-format-wrapper .description {
+  margin-top: 0.5em;
+}
+.tips {
+  font-size: 0.9em;
+  margin-bottom: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-top: 0;
+}
+
+/**
+ * Improve filter tips position.
+ */
+.tips {
+  padding-left: 0; /* LTR */
+}
+[dir="rtl"] .tips {
+  padding-right: 0;
+}

--- a/templates/filter/filter-guidelines.html.twig
+++ b/templates/filter/filter-guidelines.html.twig
@@ -1,0 +1,29 @@
+{#
+/**
+ * @file
+ * Theme override for guidelines for a text format.
+ *
+ * Available variables:
+ * - format: Contains information about the current text format, including the
+ *   following:
+ *   - name: The name of the text format, potentially unsafe and needs to be
+ *     escaped.
+ *   - format: The machine name of the text format, e.g. 'basic_html'.
+ * - attributes: HTML attributes for the containing element.
+ * - tips: Descriptions and a CSS ID in the form of 'module-name/filter-id'
+ *   (only used when 'long' is TRUE) for each filter in one or more text
+ *   formats.
+ *
+ * @see template_preprocess_filter_tips()
+ */
+#}
+{%
+  set classes = [
+    'filter-guidelines__item',
+    'filter-guidelines__item--' ~ format.id|clean_class,
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  <h4 class="label">{{ format.label }}</h4>
+  {{ tips }}
+</div>

--- a/templates/form-element.html.twig
+++ b/templates/form-element.html.twig
@@ -8,6 +8,10 @@
  * @see template_preprocess_form_element()
  */
 #}
+{#
+  Most of core-provided js assumes that the CSS class pattern js-form-item-[something] or
+  js-form-type-[something] exists on form items. We have to keep them.
+#}
 {%
   set classes = [
     'js-form-item',

--- a/templates/text-format-wrapper.html.twig
+++ b/templates/text-format-wrapper.html.twig
@@ -1,0 +1,41 @@
+{#
+/**
+ * @file
+ * Theme override for a text format-enabled form element.
+ *
+ * @todo Remove when https://www.drupal.org/node/3016346 and
+ * https://www.drupal.org/node/3016343 are fixed.
+ *
+ * Available variables:
+ * - children: Text format element children.
+ * - description: Text format element description.
+ * - attributes: HTML attributes for the containing element.
+ * - aria_description: Flag for whether or not an ARIA description has been
+ *   added to the description container.
+ * - description_attributes: attributes for the description.
+ *   @see https://www.drupal.org/node/3016343
+ * - disabled: An indicator for whether the associated form element is disabled,
+ *   added by this theme.
+ *   @see https://www.drupal.org/node/3016346
+ *
+ * @see template_preprocess_text_format_wrapper()
+ */
+#}
+{%
+  set classes = [
+    'js-form-item',
+    'form-item',
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {{ children }}
+  {% if description %}
+    {%
+      set description_classes = [
+        aria_description ? 'form-item__description',
+        disabled ? 'is-disabled',
+      ]
+    %}
+    <div{{ description_attributes.addClass(description_classes) }}>{{ description }}</div>
+  {% endif %}
+</div>

--- a/variables.js
+++ b/variables.js
@@ -47,12 +47,13 @@ module.exports = {
     '--color-input-border': 'var(--color-grayblue)',
     '--color-input-border-hover': 'var(--color-text)',
     '--color-input-border-focus': 'var(--color-absolutezero)',
+    '--color-input-focus-shadow': 'rgba(0, 74, 220, 0.3)', // Absolute zero with opacity.
     '--color-input-error': 'var(--color-maximumred)',
     '--color-input-border-error': 'var(--color-maximumred)',
-    '--color-input-label-disabled': 'rgba(84, 85, 96, 0.6)', // Davy's grey with opacity.
+    '--color-input-label-disabled': 'rgba(84, 85, 96, 0.6)', // Davy's grey with 0.6 opacity.
     '--color-input-fg-disabled': 'var(--color-oldsilver)',
-    '--color-input-bg-disabled': 'rgba(212, 212, 216, 0.3)', // Light gray with opacity.
-    '--color-input-border-disabled': 'rgba(130, 130, 140, 0.5)', // Old silver with opacity.
+    '--color-input-bg-disabled': '#f2f2f3', // Light gray with 0.3 opacity on white bg.
+    '--color-input-border-disabled': '#bababf', // Old silver with 0.5 opacity on white bg.
     '--opacity-input-border-disabled': '0.5',
     '--size-input-border-radius': '0.125em', // (1/8)em ~ 2px
     '--size-input-border': '0.0625em', // (1/16)em ~ 1px


### PR DESCRIPTION
## Issue

This PR fix #21.

## Screenshots before/after (now Chrome on OSX only)

![01--textarea--mac-os-x--chrome](https://user-images.githubusercontent.com/9197058/49235330-28ff6580-f3fa-11e8-82f2-194044d5afd8.png)
![02--textarea-errors--mac-os-x--chrome](https://user-images.githubusercontent.com/9197058/49235339-31f03700-f3fa-11e8-9153-27e889a2d533.png)

__Todo__


## Testing instructions

* Add `https://github.com/zolhorvath/seven-refresh/` as `drupal-profile` (`sevenrefresh`) to a Drupal project.
* Remove `core/themes/seven`
* Make sure that this theme is installed to `themes/custom/seven`
* Symlink `core/misc` to `themes/custom/misc`
* Run `yarn && yarn build:css` in the theme's root
* Install a Drupal with profile `sevenrefresh`. This will enable additional field types such as `telephone` or `date_range` and enable `styleguide` drupal module as well

After that Drupal is installed, Styleguide will be the front page and you'll have the test form at `/contact/textarea`.